### PR TITLE
Handle multiple inline links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+- Handle multiple inline links ([#1])
+
 ### 1.0.0
 
 - Initial release.
+
+<!-- LINKS -->
+
+[#1]:https://github.com/godaddy/dmd/pull/1

--- a/helpers.js
+++ b/helpers.js
@@ -1,6 +1,9 @@
 const slugs = new Map();
 
-const reInlineLinks = /(\[(.+)\])(\(([^)\s]+)\))/g;
+// captures multiple inline links
+const reInlineLinks = /(?<!\\)(\[([^(]+|[.+])\])(\(([^(]+)\))/g;
+// captures inline links with (parentheses) in title
+const reInlineSigLinks = /(?<!\\)(\[(.+)\])(\(([^)\s]+)\))/g;
 const reBrackets = /[^\\]\[|[^\\]]/g;
 const reLeftBrackets = /\[/g;
 const reRightBrackets = /]/g;
@@ -126,11 +129,14 @@ function refLinks(options) {
     refMap.set(name, slug);
   }
 
+  function formatLink(match, brackets, title, parentheses, link) {
+    const ref = safeRef(title, link);
+    return brackets + (ref ? `[${ref}]` : '');
+  }
+
   const content = options.fn(this)
-    .replace(reInlineLinks, (match, brackets, title, parentheses, link) => {
-      const ref = safeRef(title, link);
-      return brackets + (ref ? `[${ref}]` : '');
-    });
+    .replace(reInlineLinks, formatLink)
+    .replace(reInlineSigLinks, formatLink);
 
   let refContent = '<!-- LINKS -->\n\n';
   for (const [name, slug] of refMap) {

--- a/test/fixtures/mock.snapshot.md
+++ b/test/fixtures/mock.snapshot.md
@@ -387,22 +387,10 @@ Preset module with meta data
 [PackageIdentifier]:#packageidentifier
 [isModulePath]:#ismodulepath
 [ONE]:#one
-[pluginIdentifier(rawName, \[options\])]:#pluginidentifierrawname-options
-[isTruthy(something)]:#istruthysomething
 [ModuleInfo]:#moduleinfo
 [PluginInfo]:#plugininfo
 [PresetInfo]:#presetinfo
-[new Resolver(options)]:#new-resolveroptions
-[.resolve(moduleName)]:#loaderresolvemodulename
-[.require(moduleName)]:#loaderrequiremodulename
-[.tryResolve(moduleName)]:#loadertryresolvemodulename
-[.tryRequire(moduleName)]:#loadertryrequiremodulename
 [`Resolver`]:#new-resolveroptions
-[.getModuleInfo(module, moduleName, \[meta\])]:#loadergetmoduleinfomodule-modulename-meta
-[.loadModule(moduleName, \[meta\])]:#loaderloadmodulemodulename-meta
-[.loadPlugin(module, \[meta\])]:#loaderloadpluginmodule-meta
-[.loadPreset(module, \[meta\], \[options\])]:#loaderloadpresetmodule-meta-options
-[.loadConfigured(config)]:#loaderloadconfiguredconfig
 [`Loader`]:#loader
 [`ModuleInfo`]:#moduleinfo
 [`PluginInfo`]:#plugininfo
@@ -415,3 +403,15 @@ Preset module with meta data
 [.version]:#packageidentifierversion
 [.full]:#packageidentifierfull
 [`PackageIdentifier`]:#packageidentifier
+[pluginIdentifier(rawName, \[options\])]:#pluginidentifierrawname-options
+[isTruthy(something)]:#istruthysomething
+[new Resolver(options)]:#new-resolveroptions
+[.resolve(moduleName)]:#loaderresolvemodulename
+[.require(moduleName)]:#loaderrequiremodulename
+[.tryResolve(moduleName)]:#loadertryresolvemodulename
+[.tryRequire(moduleName)]:#loadertryrequiremodulename
+[.getModuleInfo(module, moduleName, \[meta\])]:#loadergetmoduleinfomodule-modulename-meta
+[.loadModule(moduleName, \[meta\])]:#loaderloadmodulemodulename-meta
+[.loadPlugin(module, \[meta\])]:#loaderloadpluginmodule-meta
+[.loadPreset(module, \[meta\], \[options\])]:#loaderloadpresetmodule-meta-options
+[.loadConfigured(config)]:#loaderloadconfiguredconfig

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -43,6 +43,24 @@ describe('helpers', () => {
       assume(lines).includes('[link one]:#link-one');
       assume(lines).includes('[link two]:#link-two');
     });
+
+    it('captures method signature titles of inline links', async () => {
+      const fn = () => 'Has [.method(arg1, \\[arg2\\])](#some-method)';
+      const results = helpers.refLinks({ fn });
+      const [, refLine] = splitLines(results);
+
+      assume(refLine).equals('[.method(arg1, \\[arg2\\])]:#some-method');
+    });
+
+    it('does not re-reformat links', async () => {
+      const str = 'Has [link one] and [link two] and [.method(arg1, \\[arg2\\])] in it.';
+      const fn = () => str;
+      const results = helpers.refLinks({ fn });
+      const lines = splitLines(results);
+
+      assume(lines).lengthOf(1);
+      assume(results).startsWith(str);
+    });
   });
 
   describe('shortDesc', () => {


### PR DESCRIPTION
This handles cases with multiple inline links, and when escaped brackets precede a link.